### PR TITLE
migrate from fig to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ svcdir:
   ports:
    - "9001:9001"
 etcd:
-  image: coreos/etcd:v0.5.0_alpha.5
+  image: coreos/etcd:v0.4.6
   ports:
    - "4001:4001"
    - "7001:7001"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "codestyle": "jscs -p google bin/ lib/ middleware/ resources/ test/ server.js",
     "lint": "eslint .",
     "coverage": "istanbul cover node test/fleet-watch-machines/test.js",
-    "test": "fig build && fig up -d && lab && fig stop",
+    "test": "docker-compose build && docker-compose up -d && sleep 3 && lab && docker-compose stop",
     "docs": "mkdir -p docs/generated && aglio -i docs/api-blueprint.md -o docs/generated/index.html",
     "docs-server": "st -p 9002 -d docs/generated -i index.html"
   },


### PR DESCRIPTION
## etcd version changed

etcd v0.5.0_alpha.5 does not work for me, which causes test failed, changed to v0.4.6 instead.

``` bash
# etcd v0.5.0_alpha.5:
$ etcdctl --peers http://localhost:4001 --debug ls
Error:  Cannot sync with the cluster using peers http://localhost:4001
```
## docker-compose version 1.3.0 is needed

docker-compose version 1.2.0 causes echo command not found,

``` bash
$ sudo npm test 
> paz-orchestrator@0.0.1 test /home/jacyzon/Project/paz/paz-orchestrator
> docker-compose build && docker-compose up -d && sleep 3 && lab && docker-compose stop

etcd uses an image, skipping
svcdir uses an image, skipping
scheduler uses an image, skipping
Building orchestrator...
Step 0 : FROM node:0.10
 ---> 79b27c4ea3bc
Step 1 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 50c587c34061
Step 2 : ADD ./package.json /usr/src/app/package.json
 ---> Using cache
 ---> e0dee93908da
Step 3 : RUN npm install
 ---> Using cache
 ---> fff395c17474
Step 4 : ADD ./bin /usr/src/app/bin
 ---> Using cache
 ---> 4a72f14e040a
Step 5 : ADD ./lib /usr/src/app/lib
 ---> Using cache
 ---> a3d6962b538a
Step 6 : ADD ./resources /usr/src/app/resources
 ---> Using cache
 ---> 7731f20e5b4c
Step 7 : ADD ./middleware /usr/src/app/middleware
 ---> Using cache
 ---> ce59ee6700c3
Step 8 : ADD ./server.js /usr/src/app/server.js
 ---> Using cache
 ---> a0f95be61d4c
Step 9 : EXPOSE 9000
 ---> Using cache
 ---> 2f204c24196b
Step 10 : EXPOSE 1337
 ---> Using cache
 ---> 1873fc359f55
Step 11 : CMD ./bin/server
 ---> Using cache
 ---> a16a9bf9c444

Successfully built a16a9bf9c444
Recreating pazorchestrator_etcd_1...
Cannot start container 27d8ef502a79d9b2aeaa93dbf9a9962326c33bff7eff696f4d43312b67ba1e1d: [8] System error: exec: "/bin/echo": stat /bin/echo: no such file or directory
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

see https://github.com/docker/compose/issues/919, the [patch](https://github.com/docker/compose/pull/1349) will release in v1.3.0.

**docker-compose v1.3.0 now requires Docker 1.6.0 or later.**

To install docker-compose:

> docker-compose 1.3.0rc1 is the latest version at this time.

``` bash
sudo sh -c 'curl -L https://github.com/docker/compose/releases/download/1.3.0rc1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose'
sudo chmod +x /usr/local/bin/docker-compose
```

The docker and docker-compose version that works for me:

``` bash
$ docker-compose -v
docker-compose 1.3.0rc1
```

``` bash
$ docker version
Client version: 1.6.2
Client API version: 1.18
Go version (client): go1.4.2
Git commit (client): 7c8fca2
OS/Arch (client): linux/amd64
Server version: 1.6.2
Server API version: 1.18
Go version (server): go1.4.2
Git commit (server): 7c8fca2
OS/Arch (server): linux/amd64
```

closes #5 
